### PR TITLE
Remove ios statement from package json in order for NativeScript marketplace to show correct platform support

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -6,8 +6,7 @@
     "typings": "index.d.ts",
     "nativescript": {
         "platforms": {
-            "android": "3.0.0",
-            "ios": "3.0.0"
+            "android": "3.0.0"
         }
     },
     "scripts": {


### PR DESCRIPTION
Hi,

From the looks of it it looks to me that this plugin is not supported inside an NativeScript iOS application but it has the "ios" tag inside the "nativescript" tag in its package json. This tag helps the official NativeScript plugins [marketplace website](https://market.nativescript.org/) to showcase useful information regarding any NativeScript plugin. Yours plugin is showcased [here](https://market.nativescript.org/plugins/nativescript-auto-complete-edit-text) and as you see due to the presence of the "ios" tag inside the package json it incorrectly shows that is should support iOS. This may lead to misunderstanding by the community which would like to use your plugin.

I created this simple PR to resolve this possible misunderstanding, hope you can merge it and publish a new version of your plugin.